### PR TITLE
feat(devfile): update build command

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -39,7 +39,7 @@ commands:
     exec:
       component: tools
       workingDir: ${PROJECTS_ROOT}/fuse-rest-http-booster
-      commandLine: MAVEN_OPTS='-Xmx200m' && mvn clean package
+      commandLine: "mvn clean package"
       group:
         kind: build
   - id: run


### PR DESCRIPTION
### What does this PR do?
Removes redundant MAVEN_OPTS from the 1. Build command to avoid overriding  
![screenshot-codeready-openshift-operators apps cluster-7568 7568 sandbox1862 opentlc com-2022 02 15-14_15_32](https://user-images.githubusercontent.com/1271546/154070531-621b2a83-6e71-4ba6-a45d-60923f383fe7.png)


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-2752
