### PR TITLE
chore: bump to Universal Developer Image #udi-rhel8:2.16

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -2,17 +2,10 @@ schemaVersion: 2.1.0
 metadata:
   name: java-fuse
 components:
+
   - name: tools
     container:
-      image: registry.redhat.io/codeready-workspaces/plugin-java8-rhel8
-      env:
-        - name: JAVA_OPTS
-          value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
-            -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
-            -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom
-            -Duser.home=/home/jboss"
-        - name: MAVEN_OPTS
-          value: $(JAVA_OPTS)
+      image: quay.io/crw/udi-rhel8:2.16
       memoryLimit: 3Gi
       endpoints:
         - exposure: public
@@ -25,15 +18,12 @@ components:
           targetPort: 5005
       volumeMounts:
         - name: m2
-          path: /home/jboss/.m2
-        - name: gradle
-          path: /home/jboss/.gradle
+          path: /home/user/.m2
+
   - name: m2
     volume:
       size: 1G
-  - name: gradle
-    volume:
-      size: 1G
+
 commands:
   - id: build
     exec:


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

Uses `quay.io/crw/udi-rhel8:2.16` for tooling container