### PR TITLE
chore: change docker image used for deploying to the OS cluster

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <fuse.bom.version>7.10.0.fuse-sb2-7_10_0-00014-redhat-00001</fuse.bom.version>
-        <docker.image.version>registry.redhat.io/fuse7/fuse-java-openshift-rhel8:1.10</docker.image.version>
+        <docker.image.version>registry.redhat.io/fuse7/fuse-java-openshift-jdk11-rhel8:1.10</docker.image.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>
Use **registry.redhat.io/fuse7/fuse-java-openshift-jdk11-rhel8:1.10** image for deployin to the OS. This image is supported by AMD64 and Intel 64 (x86_64), IBM Z and LinuxONE (s390x) and IBM Power Systems (ppc64le)

Related issue: https://issues.redhat.com/browse/CRW-2592
![screenshot-devspaces-openshift-operators apps ppc64le-qe31 psi redhat com-2022 05 19-16_29_56](https://user-images.githubusercontent.com/1271546/169337024-6252b99f-e0c5-4fe8-9db1-6280f6944069.png)
![screenshot-fuse-rest-http-booster-test apps ppc64le-qe31 psi redhat com-2022 05 19-16_30_59](https://user-images.githubusercontent.com/1271546/169337063-f3236c0c-1cf2-42d7-8257-d5e1bacb10a1.png)

