### PR TITLE
chore: update oc deploy and oc login commands

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -49,8 +49,9 @@ commands:
       workingDir: ${PROJECTS_ROOT}/fuse-rest-http-booster
       commandLine: |
           echo
-          echo "Before you can deploy this application to an openshift cluster,"
-          echo "you must run 'oc login ...' in the tools terminal."
+          echo "You are already logged in to the current cluster. However, if you want"
+          echo "to deploy this application to a different OpenShift cluster, you must"
+          echo "run 'oc login ...' in the tools terminal."
           echo
       group:
         kind: run
@@ -58,6 +59,6 @@ commands:
     exec:
       component: tools
       workingDir: ${PROJECTS_ROOT}/fuse-rest-http-booster
-      commandLine: "mvn oc:deploy -Popenshift -DskipTests"
+      commandLine: "oc project $DEVWORKSPACE_NAMESPACE && mvn oc:deploy -Popenshift -DskipTests"
       group:
         kind: run


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

- Update deploy-info command
- Use DEVWORKSPACE_NAMESPACE env to select project where the application will be deployed

![screenshot-devspaces apps ocp411 crw-qe com-2022 08 18-13_23_32](https://user-images.githubusercontent.com/1271546/185382796-a12e9487-6670-4d40-b082-9181009cb60f.png)

Related issue: https://issues.redhat.com/browse/CRW-3214
